### PR TITLE
Fix Covers  position and target level

### DIFF
--- a/custom_components/dirigera_platform/cover.py
+++ b/custom_components/dirigera_platform/cover.py
@@ -85,26 +85,26 @@ class ikea_blinds(CoverEntity):
     
     @property
     def is_closed(self):
-        if self.current_cover_position() is None:
+        if self.current_cover_position is None:
             return False 
-        return self.current_cover_position() == 100 
+        return self.current_cover_position == 100 
     
     @property
     def is_closing(self):
-        if self.current_cover_position() is None or self.target_cover_position() is False:
+        if self.current_cover_position is None or self.target_cover_position is False:
             return False 
         
-        if self.current_cover_position() != 100 and self.target_cover_position() == 100:
+        if self.current_cover_position != 100 and self.target_cover_position == 100:
             return True
              
         return False 
     
     @property
     def is_opening(self):
-        if self.current_cover_position() is None or self.target_cover_position() is False:
+        if self.current_cover_position is None or self.target_cover_position is False:
             return False 
         
-        if self.current_cover_position() != 0 and self.target_cover_position() == 0:
+        if self.current_cover_position != 0 and self.target_cover_position == 0:
             return True    
     
         return False 
@@ -116,7 +116,7 @@ class ikea_blinds(CoverEntity):
         self._json_data.set_target_position(100)
     
     def set_cover_position(self, **kwargs):
-        position = int(kwargs[0])
+        position = int(kwargs['set_target_level'])
         if position >= 0 and position <= 100:
             self._json_data.set_target_position(position)
 

--- a/custom_components/dirigera_platform/cover.py
+++ b/custom_components/dirigera_platform/cover.py
@@ -116,7 +116,7 @@ class ikea_blinds(CoverEntity):
         self._json_data.set_target_position(100)
     
     def set_cover_position(self, **kwargs):
-        position = int(kwargs['set_target_level'])
+        position = int(kwargs['position'])
         if position >= 0 and position <= 100:
             self._json_data.set_target_position(position)
 

--- a/custom_components/dirigera_platform/cover.py
+++ b/custom_components/dirigera_platform/cover.py
@@ -118,7 +118,7 @@ class ikea_blinds(CoverEntity):
     def set_cover_position(self, **kwargs):
         position = int(kwargs['position'])
         if position >= 0 and position <= 100:
-            self._json_data.set_target_position(position)
+            self._json_data.set_target_level(position)
 
     def update(self):
         logger.debug("cover update...")

--- a/custom_components/dirigera_platform/cover.py
+++ b/custom_components/dirigera_platform/cover.py
@@ -110,10 +110,10 @@ class ikea_blinds(CoverEntity):
         return False 
 
     def open_cover(self, **kwargs):
-        self._json_data.set_target_position(0)
+        self._json_data.set_target_level(0)
         
     def close_cover(self, **kwargs):
-        self._json_data.set_target_position(100)
+        self._json_data.set_target_level(100)
     
     def set_cover_position(self, **kwargs):
         position = int(kwargs['position'])


### PR DESCRIPTION
Hi, I make some fixes to make it working. I tested it on my KADRILJ roller blind

1. **Covers level**
  Current_cover_position is a integer so it's not callable. 
  ```python
    File "/workspaces/core/custom_components/dirigera_platform/cover.py", line 95, in current_cover_position
      return self._json_data.attributes.blinds_current_level()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: 'int' object is not callable
  ```

2. **Covers control attribute**
Changed _set_target_position_ attribute to _set_target_level_. 
```python
  File "/workspaces/core/custom_components/dirigera_platform/cover.py", line 136, in set_cover_position
    print(self._json_data.set_target_position(position))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Blind' object has no attribute 'set_target_position'
```