### PR TITLE
Wrong blinds and environment sensor type mapping

### DIFF
--- a/custom_components/dirigera_platform/dirigera_lib_patch.py
+++ b/custom_components/dirigera_platform/dirigera_lib_patch.py
@@ -4,6 +4,7 @@ from dirigera.devices.motion_sensor import MotionSensor
 from dirigera.devices.open_close_sensor import OpenCloseSensor, dict_to_open_close_sensor
 from dirigera.devices.environment_sensor import EnvironmentSensor, dict_to_environment_sensor
 from dirigera.devices.air_purifier import AirPurifier, dict_to_air_purifier
+from dirigera.devices.blinds import Blind, dict_to_blind
 from dirigera.hub.abstract_smart_home_hub import AbstractSmartHomeHub
 from typing import Any, Dict, List
 
@@ -41,17 +42,17 @@ class HubX(Hub):
             raise ValueError("Device is not an OpenCloseSensor")
         return dict_to_open_close_sensor(open_close_sensor, self)
     
-    def get_environment_sensor_by_id(self, id_: str) -> OpenCloseSensor:
+    def get_environment_sensor_by_id(self, id_: str) -> EnvironmentSensor:
         environment_sensor = self._get_device_data_by_id(id_)
         if environment_sensor["deviceType"] != "environmentSensor":
             raise ValueError("Device is not an EnvironmentSensor")
         return dict_to_environment_sensor(environment_sensor, self)
     
-    def get_blinds_by_id(self, id_: str) -> OpenCloseSensor:
+    def get_blinds_by_id(self, id_: str) -> Blind:
         blind_sensor = self._get_device_data_by_id(id_)
         if blind_sensor["deviceType"] != "blinds":
             raise ValueError("Device is not a Blind")
-        return dict_to_environment_sensor(blind_sensor, self)
+        return dict_to_blind(blind_sensor, self)
     
     def get_air_purifier_by_id(self, id_: str) -> AirPurifier:
         air_purifier_device = self._get_device_data_by_id(id_)


### PR DESCRIPTION
When HA was booting up, errors regarding blind position updates appeared:
```python
2024-03-03 21:19:18.724 ERROR (SyncWorker_3) [custom_components.dirigera_platform] error encountered running update on : Kitchen blind
2024-03-03 21:19:18.726 ERROR (SyncWorker_3) [custom_components.dirigera_platform] 6 validation errors for EnvironmentSensor
attributes -> currentTemperature
  field required (type=value_error.missing)
attributes -> currentRH
  field required (type=value_error.missing)
attributes -> currentPM25
  field required (type=value_error.missing)
attributes -> maxMeasuredPM25
  field required (type=value_error.missing)
attributes -> minMeasuredPM25
  field required (type=value_error.missing)
attributes -> vocIndex
  field required (type=value_error.missing)
2024-03-03 21:19:18.728 ERROR (MainThread) [homeassistant.helpers.entity] Update for cover.kitchen_blind fails
Traceback (most recent call last):
  File "/workspaces/core/custom_components/dirigera_platform/cover.py", line 141, in update
    self._json_data = self._hub.get_blinds_by_id(self._json_data.id)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/custom_components/dirigera_platform/dirigera_lib_patch.py", line 54, in get_blinds_by_id
    return dict_to_environment_sensor(blind_sensor, self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.11/site-packages/dirigera/devices/environment_sensor.py", line 36, in dict_to_environment_sensor
    return EnvironmentSensor(dirigeraClient=dirigera_client, **data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 6 validation errors for EnvironmentSensor
attributes -> currentTemperature
  field required (type=value_error.missing)
attributes -> currentRH
  field required (type=value_error.missing)
attributes -> currentPM25
  field required (type=value_error.missing)
attributes -> maxMeasuredPM25
  field required (type=value_error.missing)
attributes -> minMeasuredPM25
  field required (type=value_error.missing)
attributes -> vocIndex
  field required (type=value_error.missing)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity.py", line 942, in async_update_ha_state
    await self.async_device_update()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1261, in async_device_update
    await hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/custom_components/dirigera_platform/cover.py", line 145, in update
    raise HomeAssistantError(ex, DOMAIN, "hub_exception")
homeassistant.exceptions.HomeAssistantError: (ValidationError(model='EnvironmentSensor', errors=[{'loc': ('attributes', 'currentTemperature'), 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ('attributes', 'currentRH'), 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ('attributes', 'currentPM25'), 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ('attributes', 'maxMeasuredPM25'), 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ('attributes', 'minMeasuredPM25'), 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ('attributes', 'vocIndex'), 'msg': 'field required', 'type': 'value_error.missing'}]), 'dirigera_platform', 'hub_exception')
```
And i saw there are some copy-paste error in get_blinds_by_id. The blinds tried to be an environmental sensor, but to no avail. 
Also environment sensor wrong mapping as OpenCloseSensor. 