### PR TITLE
Pre-populate area name based on Dirigera room definition

### DIFF
--- a/custom_components/dirigera_platform/binary_sensor.py
+++ b/custom_components/dirigera_platform/binary_sensor.py
@@ -104,6 +104,7 @@ class ikea_motion_sensor(BinarySensorEntity):
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property
@@ -142,6 +143,7 @@ class ikea_open_close(ikea_motion_sensor):
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property
@@ -220,6 +222,7 @@ class ikea_water_sensor_device:
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property

--- a/custom_components/dirigera_platform/cover.py
+++ b/custom_components/dirigera_platform/cover.py
@@ -68,6 +68,7 @@ class IkeaBlinds(CoverEntity):
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property

--- a/custom_components/dirigera_platform/fan.py
+++ b/custom_components/dirigera_platform/fan.py
@@ -193,6 +193,7 @@ class ikea_starkvind_air_purifier_device:
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property

--- a/custom_components/dirigera_platform/mocks/ikea_air_purifier_mock.py
+++ b/custom_components/dirigera_platform/mocks/ikea_air_purifier_mock.py
@@ -67,6 +67,7 @@ class ikea_starkvind_air_purifier_mock_device:
             manufacturer="MOCK",
             model="Mock 1.0",
             sw_version="Mock SW 1.0",
+            suggested_area="Kitchen",
         )
 
     @property

--- a/custom_components/dirigera_platform/mocks/ikea_blinds_mock.py
+++ b/custom_components/dirigera_platform/mocks/ikea_blinds_mock.py
@@ -46,6 +46,7 @@ class ikea_blinds_mock(CoverEntity):
             manufacturer=self._manufacturer,
             model=self._model,
             sw_version=self._sw_version,
+            suggested_area="Bedroom",
         )
 
     @property

--- a/custom_components/dirigera_platform/mocks/ikea_open_close_mock.py
+++ b/custom_components/dirigera_platform/mocks/ikea_open_close_mock.py
@@ -33,6 +33,7 @@ class ikea_open_close_mock(BinarySensorEntity):
             manufacturer=self._manufacturer,
             model=self._model,
             sw_version=self._sw_version,
+            suggested_area="Living room",
         )
 
     @property

--- a/custom_components/dirigera_platform/sensor.py
+++ b/custom_components/dirigera_platform/sensor.py
@@ -147,6 +147,7 @@ class ikea_vindstyrka_device:
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property
@@ -308,6 +309,7 @@ class ikea_controller(SensorEntity):
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property

--- a/custom_components/dirigera_platform/switch.py
+++ b/custom_components/dirigera_platform/switch.py
@@ -65,6 +65,7 @@ class ikea_outlet(SwitchEntity):
             manufacturer=self._json_data.attributes.manufacturer,
             model=self._json_data.attributes.model,
             sw_version=self._json_data.attributes.firmware_version,
+            suggested_area=self._json_data.room.name if self._json_data.room is not None else None,
         )
 
     @property


### PR DESCRIPTION
## Describe your changes
Pre-populate area name based on Dirigera room definition.
* Leverage room names from Dirigera to pre-fill the area selector during initial configuration.
* Simplifies device-to-area assignment for users.
* While names may differ from existing area definitions, this aids users who forget a device's location.

## Checklist before submitting a pull request
- [ ] Updated base lib and added the required version in the `requirements.txt` and `manifest.json`

## Checklist for reviewer
- [ ] Select "Squash and merge" to keep commit timeline clean
