### PR TITLE
update Trigger field reference to prevent pydantic validation error

### DIFF
--- a/custom_components/dirigera_platform/scene.py
+++ b/custom_components/dirigera_platform/scene.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from dirigera import Hub
 from dirigera.devices.scene import Scene as DirigeraScene
+from dirigera.devices.scene import Trigger
 
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
@@ -25,6 +26,8 @@ async def async_setup_entry(
     """Create scene entities from Dirigera scene."""
     config = hass.data[DOMAIN][entry.entry_id]
     hub = Hub(config[CONF_TOKEN], config[CONF_IP_ADDRESS])
+
+    Trigger.update_forward_refs()
 
     # TODO: Add mock scenes
     if config[CONF_IP_ADDRESS] == "mock":

--- a/custom_components/dirigera_platform/scene.py
+++ b/custom_components/dirigera_platform/scene.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from dirigera import Hub
 from dirigera.devices.scene import Scene as DirigeraScene
-from dirigera.devices.scene import Trigger
+from dirigera.devices.scene import Trigger, TriggerDetails
 
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
@@ -28,6 +28,7 @@ async def async_setup_entry(
     hub = Hub(config[CONF_TOKEN], config[CONF_IP_ADDRESS])
 
     Trigger.update_forward_refs()
+    TriggerDetails.update_forward_refs()
 
     # TODO: Add mock scenes
     if config[CONF_IP_ADDRESS] == "mock":


### PR DESCRIPTION
## Describe your changes
Briefly describe your changes
Added Trigger forward reference field to prevent pydantic validation error in trigger and controllerType field
```python
2024-05-14 13:58:02.377 ERROR (MainThread) [homeassistant.components.scene] Error while setting up dirigera_platform platform for scene
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 351, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/workspaces/core/config/custom_components/dirigera_platform/scene.py", line 33, in async_setup_entry
    scenes: list[DirigeraScene] = await hass.async_add_executor_job(hub.get_scenes)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/dirigera/hub/hub.py", line 337, in get_scenes
    return [dict_to_scene(scene, self) for scene in scenes]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/dirigera/devices/scene.py", line 134, in dict_to_scene
    return Scene(dirigeraClient=dirigera_client, **data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 339, in __init__
    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 1076, in validate_model
    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 895, in validate
    v, errors = self._validate_sequence_like(v, values, loc, cls)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 928, in _validate_sequence_like
    r, ee = self._validate_singleton(v_, values, v_loc, cls)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1094, in _validate_singleton
    value, error = field.validate(v, values, loc=loc, cls=cls)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 884, in validate
    v, errors = self._validate_singleton(v, values, loc, cls)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1101, in _validate_singleton
    return self._apply_validators(v, values, loc, cls, self.validators)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1157, in _apply_validators
    v = validator(cls, v, values, self, self.model_config)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/class_validators.py", line 337, in <lambda>
    return lambda cls, v, values, field, config: validator(v)
                                                 ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 711, in validate
    return cls(**value)
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 339, in __init__
    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 1076, in validate_model
    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 860, in validate
    raise ConfigError(
pydantic.errors.ConfigError: field "trigger" not yet prepared so type is still a ForwardRef, you might need to call Trigger.update_forward_refs().
```

```python
2024-05-14 14:04:55.112 ERROR (MainThread) [homeassistant.components.scene] Error while setting up dirigera_platform platform for scene
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 351, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/workspaces/core/config/custom_components/dirigera_platform/scene.py", line 37, in async_setup_entry
    scenes: list[DirigeraScene] = await hass.async_add_executor_job(hub.get_scenes)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/dirigera/hub/hub.py", line 337, in get_scenes
    return [dict_to_scene(scene, self) for scene in scenes]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.12/site-packages/dirigera/devices/scene.py", line 134, in dict_to_scene
    return Scene(dirigeraClient=dirigera_client, **data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 339, in __init__
    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 1076, in validate_model
    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 895, in validate
    v, errors = self._validate_sequence_like(v, values, loc, cls)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 928, in _validate_sequence_like
    r, ee = self._validate_singleton(v_, values, v_loc, cls)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1094, in _validate_singleton
    value, error = field.validate(v, values, loc=loc, cls=cls)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 884, in validate
    v, errors = self._validate_singleton(v, values, loc, cls)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1101, in _validate_singleton
    return self._apply_validators(v, values, loc, cls, self.validators)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1157, in _apply_validators
    v = validator(cls, v, values, self, self.model_config)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/class_validators.py", line 337, in <lambda>
    return lambda cls, v, values, field, config: validator(v)
                                                 ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 711, in validate
    return cls(**value)
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 339, in __init__
    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 1076, in validate_model
    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 884, in validate
    v, errors = self._validate_singleton(v, values, loc, cls)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1101, in _validate_singleton
    return self._apply_validators(v, values, loc, cls, self.validators)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 1157, in _apply_validators
    v = validator(cls, v, values, self, self.model_config)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/class_validators.py", line 337, in <lambda>
    return lambda cls, v, values, field, config: validator(v)
                                                 ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 711, in validate
    return cls(**value)
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 339, in __init__
    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 1076, in validate_model
    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/fields.py", line 860, in validate
    raise ConfigError(
pydantic.errors.ConfigError: field "controllerType" not yet prepared so type is still a ForwardRef, you might need to call TriggerDetails.update_forward_refs().
```

## Checklist before submitting a pull request
- [ ] Updated base lib and added the required version in the `requirements.txt` and `manifest.json`

## Checklist for reviewer
- [ ] Select "Squash and merge" to keep commit timeline clean
