### PR TITLE
Fix event propogation

### DIFF
--- a/custom_components/dirigera_platform/base_classes.py
+++ b/custom_components/dirigera_platform/base_classes.py
@@ -78,7 +78,7 @@ class ikea_base_device:
     # To ensure state update of hass is cascaded
     def async_schedule_update_ha_state(self, force_refresh:bool = False) -> None:
         for listener in self._listeners:
-            listener.async_schedule_update_ha_state(force_refresh)
+            listener.schedule_update_ha_state(force_refresh)
 
 class ikea_base_device_sensor():
     def __init__(self,  device, id_suffix:str = "", name_suffix:str = ""):


### PR DESCRIPTION
# Description
This PR fixes event propagation to ensure that sensors, such as parasoll door sensors, are updated instantly.

# What does this fix?
This code addresses the following exception, which occurs when an asynchronous function is called from a thread while Home Assistant expects the non-asynchronous function to be called:
```
2024-05-21 12:27:26.607 ERROR (Thread-9) [custom_components.dirigera_platform] Detected that custom integration 'dirigera_platform' calls async_write_ha_state from a thread at custom_components/dirigera_platform/base_classes.py, line 81: listener.async_schedule_update_ha_state(force_refresh). Please report it to the author of the 'dirigera_platform' custom integration.
```