### PR TITLE
show the current state of outlets

### DIFF
--- a/custom_components/dirigera_platform/switch.py
+++ b/custom_components/dirigera_platform/switch.py
@@ -60,10 +60,6 @@ class ikea_outlet(ikea_base_device):
     def __init__(self, hass, hub, json_data):
         super().__init__(hass, hub, json_data, hub.get_outlet_by_id)
 
-    @property
-    def is_on(self):
-        return self._device.is_on
-
     async def async_turn_on(self):
         logger.debug("outlet turn_on")
         try:
@@ -86,6 +82,10 @@ class ikea_outlet_switch_sensor(ikea_base_device_sensor, SwitchEntity):
     def __init__(self, device):
         super().__init__(device = device, name = device.name )
         
+    @property
+    def is_on(self):
+        return self._device.is_on
+
     async def async_turn_on(self):
         logger.debug("sensor: outlet turn_on")
         await self._device.async_turn_on()

--- a/custom_components/dirigera_platform/switch.py
+++ b/custom_components/dirigera_platform/switch.py
@@ -60,6 +60,10 @@ class ikea_outlet(ikea_base_device):
     def __init__(self, hass, hub, json_data):
         super().__init__(hass, hub, json_data, hub.get_outlet_by_id)
 
+    @property
+    def is_on(self):
+        return self._device.is_on
+
     async def async_turn_on(self):
         logger.debug("outlet turn_on")
         try:


### PR DESCRIPTION
## Add support to show current state for outlets
Currently, outlets only provide actions to switch them on and off. They currently don't show their state because the device class has no is_on property.