### PR TITLE
Fix IKEA STARKVIND native unit of measurement

### DIFF
--- a/custom_components/dirigera_platform/base_classes.py
+++ b/custom_components/dirigera_platform/base_classes.py
@@ -664,7 +664,7 @@ class ikea_starkvind_air_purifier_sensor(ikea_base_device_sensor, SensorEntity):
                     id_suffix=prefix,
                     name=prefix,
                     device_class=device_class,
-                    native_unit_of_measurement=native_uom,
+                    native_unit_of_measurement=native_unit_of_measurement,
                     icon=icon_name)
 
         self._native_value_prop = native_value_prop

--- a/custom_components/dirigera_platform/sensor.py
+++ b/custom_components/dirigera_platform/sensor.py
@@ -23,7 +23,7 @@ from .ikea_gateway import ikea_gateway
 
 from homeassistant import config_entries, core
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN, UnitOfTime, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 from homeassistant.core import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 
@@ -114,7 +114,7 @@ async def add_air_purifier_sensors(async_add_entities, air_purifiers):
                 prefix="Filter Lifetime",
                 device_class=SensorDeviceClass.DURATION,
                 native_value_prop="filter_lifetime",
-                native_uom="min",
+                native_unit_of_measurement=UnitOfTime.MINUTES,
                 icon_name="mdi:clock-time-eleven-outline",
             )
         )
@@ -125,7 +125,7 @@ async def add_air_purifier_sensors(async_add_entities, air_purifiers):
                 prefix="Filter Elapsed Time",
                 device_class=SensorDeviceClass.DURATION,
                 native_value_prop="filter_elapsed_time",
-                native_uom="min",
+                native_unit_of_measurement=UnitOfTime.MINUTES,
                 icon_name="mdi:timelapse",
             )
         )
@@ -136,7 +136,7 @@ async def add_air_purifier_sensors(async_add_entities, air_purifiers):
                 prefix="Current pm25",
                 device_class=SensorDeviceClass.PM25,
                 native_value_prop="current_p_m25",
-                native_uom="µg/m³",
+                native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
                 icon_name="mdi:molecule",
             )
         )
@@ -147,7 +147,7 @@ async def add_air_purifier_sensors(async_add_entities, air_purifiers):
                 prefix="Motor Runtime",
                 device_class=SensorDeviceClass.DURATION,
                 native_value_prop="motor_runtime",
-                native_uom="min",
+                native_unit_of_measurement=UnitOfTime.MINUTES,
                 icon_name="mdi:run-fast",
             )
         )


### PR DESCRIPTION
## Describe your changes

Change `native_uom` to `native_unit_of_measurement` and make use of unit constants.

Fixes the following error message, as seen with at least Home Assistant 2025.7 and later.

    2025-08-07 00:00:00.000 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up dirigera_platform platform for sensor: ikea_starkvind_air_purifier_sensor.__init__() got an unexpected keyword argument 'native_uom'
    homeassistant  | Traceback (most recent call last):
    homeassistant  |   File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    homeassistant  |     await asyncio.shield(awaitable)
    homeassistant  |   File "/config/custom_components/dirigera_platform/sensor.py", line 67, in async_setup_entry
    homeassistant  |     await add_air_purifier_sensors(async_add_entities, platform.air_purifiers)
    homeassistant  |   File "/config/custom_components/dirigera_platform/sensor.py", line 112, in add_air_purifier_sensors
    homeassistant  |     ikea_starkvind_air_purifier_sensor(
    homeassistant  |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
    homeassistant  |         device=air_purifier,
    homeassistant  |         ^^^^^^^^^^^^^^^^^^^^
    homeassistant  |     ...<4 lines>...
    homeassistant  |         icon_name="mdi:clock-time-eleven-outline",
    homeassistant  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    homeassistant  |     )
    homeassistant  |     ^
    homeassistant  | TypeError: ikea_starkvind_air_purifier_sensor.__init__() got an unexpected keyword argument 'native_uom'

## Checklist before submitting a pull request
- [x] Updated base lib and added the required version in the `requirements.txt` and `manifest.json`

## Checklist for reviewer
- [x] Select "Squash and merge" to keep commit timeline clean
