### PR TITLE
Add state_class to environment sensors for Long Term Statistics

### DIFF
--- a/custom_components/dirigera_platform/base_classes.py
+++ b/custom_components/dirigera_platform/base_classes.py
@@ -390,11 +390,12 @@ class ikea_vindstyrka_humidity(ikea_base_device_sensor, SensorEntity):
     def __init__(self, device: ikea_vindstyrka_device) -> None:
         logger.debug("ikea_vindstyrka_humidity ctor...")
         super().__init__(
-                    device, 
-                    id_suffix="HUM", 
+                    device,
+                    id_suffix="HUM",
                     name="Humidity",
                     device_class=SensorDeviceClass.HUMIDITY,
-                    native_unit_of_measurement=PERCENTAGE)
+                    native_unit_of_measurement=PERCENTAGE,
+                    state_class=SensorStateClass.MEASUREMENT)
 
     @property
     def native_value(self) -> int:
@@ -423,11 +424,12 @@ class ikea_vindstyrka_pm25(ikea_base_device_sensor, SensorEntity):
             id_suffix = "MINPM25"
             name_suffix = "Min Measured PM2.5"
         
-        super().__init__(device, 
-                         id_suffix=id_suffix, 
+        super().__init__(device,
+                         id_suffix=id_suffix,
                          name=name_suffix,
                          device_class=SensorDeviceClass.PM25,
-                         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+                         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                         state_class=SensorStateClass.MEASUREMENT)
 
     @property
     def native_value(self) -> int:
@@ -444,11 +446,12 @@ class ikea_vindstyrka_voc_index(ikea_base_device_sensor, SensorEntity):
     def __init__(self, device: ikea_vindstyrka_device) -> None:
         logger.debug("ikea_vindstyrka_voc_index ctor...")
         super().__init__(
-            device, 
-            id_suffix="VOC", 
+            device,
+            id_suffix="VOC",
             name="VOC Index",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-            native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            state_class=SensorStateClass.MEASUREMENT)
 
     @property
     def native_value(self) -> int:


### PR DESCRIPTION
## Summary

Add `state_class=SensorStateClass.MEASUREMENT` to environment sensors that were missing it:

- `ikea_vindstyrka_humidity`
- `ikea_vindstyrka_pm25`
- `ikea_vindstyrka_voc_index`

Without `state_class`, Home Assistant cannot include these sensors in Long Term Statistics. The temperature sensor already had `state_class="measurement"`, but these three were missing it.

## Test plan

- [ ] Verify humidity, PM2.5, and VOC sensors appear in Developer Tools → Statistics
- [ ] Verify Long Term Statistics graphs work for these sensors after collecting some data

Fixes #154