### PR TITLE
Add ALPSTUGA CO2 sensor support

### DIFF
--- a/custom_components/dirigera_platform/base_classes.py
+++ b/custom_components/dirigera_platform/base_classes.py
@@ -20,11 +20,12 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfTemperature,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_MILLION,
     )
 
 from dirigera import Hub
 from dirigera.devices.blinds import Blind
-from dirigera.devices.environment_sensor import EnvironmentSensor
+from .dirigera_lib_patch import EnvironmentSensorX
 from dirigera.devices.controller import Controller
 from dirigera.devices.air_purifier import FanModeEnum
 
@@ -356,7 +357,7 @@ class ikea_blinds_sensor(ikea_base_device_sensor, CoverEntity):
         await self._device.async_set_cover_position(position)
 
 class ikea_vindstyrka_device(ikea_base_device):
-    def __init__(self, hass:core.HomeAssistant, hub:Hub , json_data:EnvironmentSensor) -> None:
+    def __init__(self, hass:core.HomeAssistant, hub:Hub , json_data:EnvironmentSensorX) -> None:
         super().__init__(hass, hub, json_data, hub.get_environment_sensor_by_id)
         self._updated_at = None 
 
@@ -453,6 +454,23 @@ class ikea_vindstyrka_voc_index(ikea_base_device_sensor, SensorEntity):
     @property
     def native_value(self) -> int:
         return self._device.voc_index
+
+
+class ikea_alpstuga_co2(ikea_base_device_sensor, SensorEntity):
+    """CO2 sensor for IKEA ALPSTUGA air quality monitor."""
+    def __init__(self, device: ikea_vindstyrka_device) -> None:
+        logger.debug("ikea_alpstuga_co2 ctor...")
+        super().__init__(
+            device,
+            id_suffix="CO2",
+            name="CO2",
+            device_class=SensorDeviceClass.CO2,
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION)
+
+    @property
+    def native_value(self) -> int:
+        return self._device.current_c_o2
+
 
 # SOMRIG Controllers act differently in the gateway Hub
 # While its one device but two id's are sent back each

--- a/custom_components/dirigera_platform/sensor.py
+++ b/custom_components/dirigera_platform/sensor.py
@@ -8,6 +8,7 @@ from .base_classes import (
     ikea_vindstyrka_humidity,
     ikea_vindstyrka_pm25,
     ikea_vindstyrka_voc_index,
+    ikea_alpstuga_co2,
     WhichPM25,
     ikea_starkvind_air_purifier_sensor,
     current_amps_sensor ,
@@ -73,18 +74,20 @@ async def add_environment_sensors(async_add_entities, env_devices):
         # For each device setup up multiple entities
         # Some non IKEA environment sensors only have some of the attributes
         # hence check if it exists and then add
-        if getattr(env_device,"current_temperature") is not None:
+        if getattr(env_device,"current_temperature", None) is not None:
             env_sensors.append(ikea_vindstyrka_temperature(env_device))
-        if getattr(env_device,"current_r_h") is not None:
+        if getattr(env_device,"current_r_h", None) is not None:
             env_sensors.append(ikea_vindstyrka_humidity(env_device))
-        if getattr(env_device,"current_p_m25") is not None:
+        if getattr(env_device,"current_p_m25", None) is not None:
             env_sensors.append(ikea_vindstyrka_pm25(env_device, WhichPM25.CURRENT))
-        if getattr(env_device,"max_measured_p_m25") is not None:
+        if getattr(env_device,"max_measured_p_m25", None) is not None:
             env_sensors.append(ikea_vindstyrka_pm25(env_device, WhichPM25.MAX))
-        if getattr(env_device,"min_measured_p_m25") is not None:
+        if getattr(env_device,"min_measured_p_m25", None) is not None:
             env_sensors.append(ikea_vindstyrka_pm25(env_device, WhichPM25.MIN))
-        if getattr(env_device,"voc_index") is not None:
+        if getattr(env_device,"voc_index", None) is not None:
             env_sensors.append(ikea_vindstyrka_voc_index(env_device))
+        if getattr(env_device,"current_c_o2", None) is not None:
+            env_sensors.append(ikea_alpstuga_co2(env_device))
 
     logger.debug("Found {} env entities to setup...".format(len(env_sensors)))
 


### PR DESCRIPTION
## Summary
- Adds support for IKEA ALPSTUGA air quality monitor CO2 sensor
- The dirigera library doesn't have the `current_c_o2` field in its pydantic model yet, so this creates patched classes to support it
- Adds `ikea_alpstuga_co2` sensor entity class

## Changes
- **dirigera_lib_patch.py**: Added `EnvironmentSensorAttributesX` with `current_c_o2` field, `EnvironmentSensorX` class, and hub methods
- **base_classes.py**: Added `ikea_alpstuga_co2` sensor class, updated imports
- **sensor.py**: Added CO2 sensor detection and creation, fixed getattr calls with None default

## Test plan
- [x] Tested with ALPSTUGA device - CO2 sensor entity appears in Home Assistant
- [x] Verified real-time updates via WebSocket events work correctly

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)