### PR TITLE
Stop logging hub auth token

### DIFF
--- a/custom_components/dirigera_platform/config_flow.py
+++ b/custom_components/dirigera_platform/config_flow.py
@@ -146,15 +146,12 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         # Called when configure is called from an existing configured integration
         # The first screen that is shown, asl called after IP when submitted
 
-        logger.error("OPTIONS async_step_init called....")
-        logger.error(user_input)
+        logger.debug("OPTIONS async_step_init called....")
 
         errors: Dict[str, str] = {}
 
         if user_input is not None:
-            logger.error("async step init user input is not none...")
-            logger.error("user_input is ")
-            logger.error(user_input)
+            logger.debug("async step init user input is not none...")
 
             self.ip = user_input[CONF_IP_ADDRESS]
             self.hide_device_set_bulbs = user_input[CONF_HIDE_DEVICE_SET_BULBS]
@@ -165,7 +162,7 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                 errors["base"] = "ip_not_specified"
             else:
                 try:
-                    logger.error("Moving to second step....")
+                    logger.debug("Moving to second step....")
                     if self.ip == "mock":
                         logger.warning(
                             "Using mock ip, skipping token generation step 1"
@@ -193,12 +190,11 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         self, user_input: Dict[str, Any] = None
     ) -> Dict[str, Any]:
         logger.debug("CONFIG async_step_action called....")
-        logger.debug(user_input)
         # Since IP is specified we will try and get the auth token an set that up in
         # the config for use at a later time
         errors: Dict[str, str] = {}
-        logger.error("ip {}".format(self.ip))
-        logger.error(f"hide device set bulbs {self.hide_device_set_bulbs}")
+        logger.debug("ip {}".format(self.ip))
+        logger.debug(f"hide device set bulbs {self.hide_device_set_bulbs}")
         # Try and get the token step_2
         try:
             if self.ip == "mock":
@@ -209,13 +205,11 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     get_dirigera_token_step_two, self.ip, self.code, self.code_verifier
                 )
                 logger.info("Successful generating token")
-                logger.error(token)
 
             user_input[CONF_IP_ADDRESS] = self.ip
             user_input[CONF_TOKEN] = token
             user_input[CONF_HIDE_DEVICE_SET_BULBS] = self.hide_device_set_bulbs
-            logger.error("before create entry...")
-            logger.error(user_input)
+            logger.debug("before create entry...")
 
             self.hass.config_entries.async_update_entry(self.config_entry, data=user_input,
                                                         title="IKEA Dirigera Hub : {}".format(user_input[CONF_IP_ADDRESS]),)


### PR DESCRIPTION
A quick "hey claude, is this plugin safe to use" scan highlighted that the options flow

* logged the bearer token directly (logger.error(token)) and
* dumped the full user_input `dict` (which contains `CONF_TOKEN`)  at ERROR level in two places.

The token is long-lived and grants full control of the hub, so should never be logged.
The README also instructs users to paste HA logs into public GitHub issues, risking leakage

## Results

## Describe your changes

This PR removes the token (line 212) and user_input (218) logging and downgrades the surrounding diagnostic chatter from error to debug. 

## Checklist before submitting a pull request
- [ ] ~Updated base lib and added the required version in the `requirements.txt` and `manifest.json`~ N/A (i think?)

## Checklist for reviewer
- [ ] Select "Squash and merge" to keep commit timeline clean
