### PR TITLE
Guard hs_color against bulbs that do not support HS

### DIFF
--- a/custom_components/dirigera_platform/hub_event_listener.py
+++ b/custom_components/dirigera_platform/hub_event_listener.py
@@ -326,12 +326,17 @@ class hub_event_listener(threading.Thread):
                 except Exception as ex:
                     logger.warning(f"Scene action: failed to set {key} on {device_id}: {ex}")
 
-            # Update color_mode based on scene attributes
+            # Update color_mode based on scene attributes.
+            # Only switch to a mode the bulb actually supports - otherwise HA core
+            # rejects the state write with "unsupported color mode hs, expected
+            # color_temp" (e.g. a color_temp-only bulb in a mixed device set that
+            # receives a colorHue attribute from a group scene).
             if updated and hasattr(entity, '_color_mode'):
-                if "colorHue" in attributes or "colorSaturation" in attributes:
+                supported = getattr(entity, 'supported_color_modes', None) or []
+                if ("colorHue" in attributes or "colorSaturation" in attributes) and ColorMode.HS in supported:
                     entity._color_mode = ColorMode.HS
                     logger.debug(f"Scene action: set color_mode to HS for {device_id}")
-                elif "colorTemperature" in attributes:
+                elif "colorTemperature" in attributes and ColorMode.COLOR_TEMP in supported:
                     entity._color_mode = ColorMode.COLOR_TEMP
                     logger.debug(f"Scene action: set color_mode to COLOR_TEMP for {device_id}")
 
@@ -602,11 +607,14 @@ class hub_event_listener(threading.Thread):
                         logger.warn(f"Failed to set attribute key: {key} converted to {key_attr} on device: {id}")
                         logger.warn(ex)
                                 
-                # Update color_mode for lights when color attributes change
+                # Update color_mode for lights when color attributes change.
+                # Guard against switching to a mode the bulb does not support
+                # (see _apply_scene_actions) to avoid HA core rejecting the write.
                 if device_type == "light" and hasattr(entity, '_color_mode'):
-                    if "colorHue" in attributes or "colorSaturation" in attributes:
+                    supported = getattr(entity, 'supported_color_modes', None) or []
+                    if ("colorHue" in attributes or "colorSaturation" in attributes) and ColorMode.HS in supported:
                         entity._color_mode = ColorMode.HS
-                    elif "colorTemperature" in attributes:
+                    elif "colorTemperature" in attributes and ColorMode.COLOR_TEMP in supported:
                         entity._color_mode = ColorMode.COLOR_TEMP
 
                 # Lights behave odd with hubs when setting attribute one event is generated which

--- a/custom_components/dirigera_platform/light.py
+++ b/custom_components/dirigera_platform/light.py
@@ -331,7 +331,7 @@ class ikea_bulb(LightEntity):
                 self._color_mode = ColorMode.COLOR_TEMP
                 self._ignore_update = True
 
-            if ATTR_HS_COLOR in kwargs:
+            if ATTR_HS_COLOR in kwargs and ColorMode.HS in self._supported_color_modes:
                 logger.debug("Request to set color HS")
                 hs_tuple = kwargs[ATTR_HS_COLOR]
                 self._color_hue = hs_tuple[0]
@@ -341,6 +341,15 @@ class ikea_bulb(LightEntity):
                 await self.hass.async_add_executor_job(self._json_data.set_light_color,self._color_hue, self._color_saturation)
                 self._color_mode = ColorMode.HS
                 self._ignore_update = True
+            elif ATTR_HS_COLOR in kwargs:
+                # A hs_color was requested for a bulb that does not support HS
+                # (e.g. a color_temp-only bulb reached via a mixed device set).
+                # Ignore it instead of forcing color_mode=hs, which HA core rejects
+                # with "unsupported color mode hs, expected color_temp".
+                logger.debug(
+                    "Ignoring hs_color for %s: HS not in supported color modes %s",
+                    self.name, self._supported_color_modes,
+                )
             self.async_schedule_update_ha_state(False)
         except Exception as ex:
             logger.error("error encountered turning on : {}".format(self.name))
@@ -494,15 +503,23 @@ class ikea_bulb_device_set(LightEntity):
                 await self.hass.async_add_executor_job(self.patch_command, {"colorTemperature" : ct})
                 self._controller._ignore_update = True 
 
-            if ATTR_HS_COLOR in kwargs:
+            if ATTR_HS_COLOR in kwargs and ColorMode.HS in self._controller.supported_color_modes:
                 logger.debug("Request to set color HS device_set")
                 hs_tuple = kwargs[ATTR_HS_COLOR]
                 self._color_hue = hs_tuple[0]
                 self._color_saturation = hs_tuple[1] / 100
                 # Saturation is 0 - 1 at IKEA
-                self._controller._ignore_update = True 
-                
+                self._controller._ignore_update = True
+
                 await self.hass.async_add_executor_job(self.patch_command,{ "colorHue" : self._color_hue, "colorSaturation" : self._color_saturation})
+            elif ATTR_HS_COLOR in kwargs:
+                # hs_color requested for a device set whose controller bulb does not
+                # support HS (color_temp-only). Ignore it to avoid pushing an
+                # unsupported color mode to the group.
+                logger.debug(
+                    "Ignoring hs_color for device_set %s: HS not in supported color modes %s",
+                    self.name, self._controller.supported_color_modes,
+                )
 
         except Exception as ex:
             logger.error("error encountered turning on device_set : {}".format(self.name))


### PR DESCRIPTION
## Problem

Color_temp-only bulbs (e.g. `KAJPLATS GU10 WS 575lm`) that live in a **mixed device set** get flooded with this error, repeatedly and on every startup:

```
homeassistant.exceptions.HomeAssistantError: light.kajplats_gu10_ws_575lm_5
(<class 'custom_components.dirigera_platform.light.ikea_bulb'>) set to
unsupported color mode hs, expected one of [<ColorMode.COLOR_TEMP: 'color_temp'>]
```

The command is also left half-applied.

## Root cause

`ColorMode.HS` is assigned to a bulb's `_color_mode` in three places without checking that the bulb actually supports HS:

1. **`hub_event_listener._apply_scene_actions`** — a `sceneUpdated` action carrying `colorHue`/`colorSaturation` sets `_color_mode = HS`.
2. **`hub_event_listener` `deviceStateChanged` handler** — a color event carrying `colorHue`/`colorSaturation` sets `_color_mode = HS`.
3. **`light.async_turn_on`** (both `ikea_bulb` and `ikea_bulb_device_set`) — an `ATTR_HS_COLOR` kwarg sets `_color_mode = HS`.

When a group scene / device-set color change fans a `colorHue` attribute out to a color_temp-only member, that member reports `color_mode=hs` while its `supported_color_modes` is `[color_temp]`, and HA core rejects every state write. (1) and (2) are the primary source — they fire on hub events and on startup state replay, independent of any service call.

## Fix

Only switch to `ColorMode.HS` / `ColorMode.COLOR_TEMP` when that mode is present in the entity's `supported_color_modes`. Applied at all three sites. Behavior is unchanged for bulbs that genuinely support HS.

## Testing

- Against `main` @ 3743cc6.
- Before: `unsupported color mode hs` errors on the color_temp-only GU10s on every hub event and on every HA startup.
- After: running the patched files, the event listener is confirmed live (still processing hub events) but produces **zero** color-mode errors across restarts; color and color-temperature commands on real HS bulbs still work.